### PR TITLE
Fix spring running with maven.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -130,24 +130,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>pre-integration-test</id>
-                        <goals>
-                            <goal>start</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>post-integration-test</id>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jsondoc</groupId>

--- a/server/src/test/java/de/helfenkannjeder/come2help/server/rest/AbstractControllerTest.java
+++ b/server/src/test/java/de/helfenkannjeder/come2help/server/rest/AbstractControllerTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
  * @author Valentin Zickner <valentin.zickner@helfenkannjeder.de>
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@WebIntegrationTest
+@WebIntegrationTest(randomPort = true)
 @SpringApplicationConfiguration(classes = Come2HelpApplication.class)
 public abstract class AbstractControllerTest {
 


### PR DESCRIPTION
Since there was a duplicate start of spring (one in maven configuration for cucumber) and another in the spring integration tests, it was often not possible to bring up spring in travis. This should be fixed with this PR.